### PR TITLE
[CARMAN-236] HorizontalInfoCard widget moved to UI package

### DIFF
--- a/example/lib/components_showcases.dart
+++ b/example/lib/components_showcases.dart
@@ -19,6 +19,7 @@ import 'package:car_manager_ui/showcases/cm_appbar/cm_appbar_showcase.dart';
 import 'package:car_manager_ui/showcases/dialogs_showcase.dart';
 import 'package:car_manager_ui/showcases/dropdown_showcase.dart';
 import 'package:car_manager_ui/showcases/empty_list_showcase.dart';
+import 'package:car_manager_ui/showcases/horizontal_info_card_showcase.dart';
 import 'package:car_manager_ui/showcases/icon_button_showcase.dart';
 import 'package:car_manager_ui/showcases/page_title_showcase.dart';
 import 'package:car_manager_ui/showcases/report_tile_showcase.dart';
@@ -75,5 +76,9 @@ final components = {
   ComponentModel(
     description: 'ReportTile',
     path: ReportTileShowcase.path,
+  ),
+  ComponentModel(
+    description: 'HorizontalInfoCard',
+    path: HorizontalInfoCardShowcase.path,
   ),
 };

--- a/example/lib/navigation/go_router_provider.dart
+++ b/example/lib/navigation/go_router_provider.dart
@@ -21,6 +21,7 @@ import 'package:car_manager_ui/showcases/cm_appbar/cm_appbar_showcase.dart';
 import 'package:car_manager_ui/showcases/dialogs_showcase.dart';
 import 'package:car_manager_ui/showcases/dropdown_showcase.dart';
 import 'package:car_manager_ui/showcases/empty_list_showcase.dart';
+import 'package:car_manager_ui/showcases/horizontal_info_card_showcase.dart';
 import 'package:car_manager_ui/showcases/icon_button_showcase.dart';
 import 'package:car_manager_ui/showcases/page_title_showcase.dart';
 import 'package:car_manager_ui/showcases/report_tile_showcase.dart';
@@ -186,6 +187,16 @@ class GoRouterHelper {
         pageBuilder: (_, state) {
           return _getPage(
             child: const ReportTileShowcase(),
+            state: state,
+          );
+        },
+      ),
+      GoRoute(
+        parentNavigatorKey: _appNavigatorKey,
+        path: HorizontalInfoCardShowcase.path,
+        pageBuilder: (_, state) {
+          return _getPage(
+            child: const HorizontalInfoCardShowcase(),
             state: state,
           );
         },

--- a/example/lib/showcases/horizontal_info_card_showcase.dart
+++ b/example/lib/showcases/horizontal_info_card_showcase.dart
@@ -1,0 +1,78 @@
+// Copyright 2024 Danchez
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:car_manager_ui/showcase_utils.dart';
+import 'package:car_manager_ui/showcases/showcase_app_base.dart';
+import 'package:carmanager_ui/carmanager_ui.dart';
+import 'package:flutter/material.dart';
+
+/// The [HorizontalInfoCardShowcase] class provides a visual representation of [HorizontalInfoCard].
+class HorizontalInfoCardShowcase extends StatelessWidget {
+  /// This path is used to navigate to the HorizontalInfoCard showcase using GoRouter.
+  static String path = '/horizontalInfoCard';
+
+  const HorizontalInfoCardShowcase({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShowcaseAppBase(
+      title: 'HorizontalInfoCard showcase',
+      children: [
+        createShowcaseTitle(
+          'Displays a card with a vertical layout featuring a primary value and a description.',
+        ),
+        const HorizontalInfoCard(
+          textValue: '100',
+          textDescription: 'Text description',
+        ),
+        createShowcaseTitle(
+          'Vertical stack of HorizontalInfoCard showcasing different metrics.',
+        ),
+        const Column(
+          children: [
+            HorizontalInfoCard(
+              textValue: '60',
+              textDescription: 'Text Description',
+            ),
+            SizedBox(height: 10),
+            HorizontalInfoCard(
+              textValue: '500000',
+              textDescription: 'Monthly Earnings',
+            ),
+          ],
+        ),
+        createShowcaseTitle(
+          'Two HorizontalInfoCard side by side, each adapting to the available width.',
+        ),
+        const Row(
+          children: [
+            Flexible(
+              child: HorizontalInfoCard(
+                textValue: '1000',
+                textDescription: 'Text Description',
+              ),
+            ),
+            SizedBox(width: 10),
+            Flexible(
+              child: HorizontalInfoCard(
+                textValue: '30',
+                textDescription: 'Description',
+              ),
+            ),
+          ],
+        )
+      ],
+    );
+  }
+}

--- a/example/lib/showcases/horizontal_info_card_showcase.dart
+++ b/example/lib/showcases/horizontal_info_card_showcase.dart
@@ -30,7 +30,7 @@ class HorizontalInfoCardShowcase extends StatelessWidget {
       title: 'HorizontalInfoCard showcase',
       children: [
         createShowcaseTitle(
-          'Displays a card with a vertical layout featuring a primary value and a description.',
+          'Displays a card with a horizontal layout featuring a primary value and a description.',
         ),
         const HorizontalInfoCard(
           textValue: '100',
@@ -71,7 +71,14 @@ class HorizontalInfoCardShowcase extends StatelessWidget {
               ),
             ),
           ],
-        )
+        ),
+        createShowcaseTitle(
+          'HorizontalInfoCard with long description',
+        ),
+        const HorizontalInfoCard(
+          textValue: '100',
+          textDescription: 'This is a showcase with long description for HorizontalInfoCard in HorizontalInfoCardShowcase',
+        ),
       ],
     );
   }

--- a/lib/carmanager_ui.dart
+++ b/lib/carmanager_ui.dart
@@ -28,6 +28,7 @@ export 'package:carmanager_ui/src/components/dialogs/error/error_dialog_route.da
 export 'package:carmanager_ui/src/components/dialogs/loading/loading_dialog_data.dart';
 export 'package:carmanager_ui/src/components/dialogs/loading/loading_dialog_route.dart';
 export 'package:carmanager_ui/src/components/dropdown/cm_dropdown.dart';
+export 'package:carmanager_ui/src/components/horizontal_info_card.dart';
 export 'package:carmanager_ui/src/components/loader/loader.dart';
 export 'package:carmanager_ui/src/components/report_tile/report_tile.dart';
 export 'package:carmanager_ui/src/components/text_field/cm_multiline_text_field.dart';

--- a/lib/src/components/horizontal_info_card.dart
+++ b/lib/src/components/horizontal_info_card.dart
@@ -1,0 +1,86 @@
+// Copyright 2024 Danchez
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:carmanager_ui/src/constants/app_colors_constants.dart';
+import 'package:carmanager_ui/src/constants/text_constants.dart';
+import 'package:flutter/material.dart';
+
+/// The [HorizontalInfoCard] widget displays a card with a vertical layout featuring a [textValue]
+/// and a [textDescription]. The card is styled with a shadow and rounded corners, and it adjusts
+/// to the full width of its container.
+///
+/// Example usage:
+/// ```dart
+/// HorizontalInfoCard(
+///   textValue: '1000',
+///   textDescription: 'Description',
+/// )
+/// ```
+class HorizontalInfoCard extends StatelessWidget {
+  final String textValue;
+  final String textDescription;
+
+  const HorizontalInfoCard({
+    super.key,
+    required this.textValue,
+    required this.textDescription,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: const BoxDecoration(
+          color: kWhite,
+          boxShadow: [
+            BoxShadow(
+              color: kBoxShadowColor,
+              blurRadius: 4,
+              offset: Offset(0, 5),
+            )
+          ],
+          borderRadius: BorderRadius.all(Radius.circular(6))),
+      child: Container(
+        decoration:
+            const BoxDecoration(color: kPrimaryColorWithOpacityBG, borderRadius: BorderRadius.all(Radius.circular(6))),
+        child: Padding(
+          padding: const EdgeInsets.only(right: 12, top: 20, left: 12, bottom: 15),
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  textValue,
+                  style: kTitleTextStyle.copyWith(
+                    color: kkMyrtleGreenWithOpacity,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Text(
+                  textDescription,
+                  style: kCaptionTextStyle.copyWith(
+                    fontWeight: FontWeight.w300,
+                    color: kkMyrtleGreenWithOpacity,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/components/horizontal_info_card.dart
+++ b/lib/src/components/horizontal_info_card.dart
@@ -16,7 +16,7 @@ import 'package:carmanager_ui/src/constants/app_colors_constants.dart';
 import 'package:carmanager_ui/src/constants/text_constants.dart';
 import 'package:flutter/material.dart';
 
-/// The [HorizontalInfoCard] widget displays a card with a vertical layout featuring a [textValue]
+/// The [HorizontalInfoCard] widget displays a card with a horizontal layout featuring a [textValue]
 /// and a [textDescription]. The card is styled with a shadow and rounded corners, and it adjusts
 /// to the full width of its container.
 ///
@@ -56,28 +56,29 @@ class HorizontalInfoCard extends StatelessWidget {
             const BoxDecoration(color: kPrimaryColorWithOpacityBG, borderRadius: BorderRadius.all(Radius.circular(6))),
         child: Padding(
           padding: const EdgeInsets.only(right: 12, top: 20, left: 12, bottom: 15),
-          child: FittedBox(
-            fit: BoxFit.scaleDown,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  textValue,
-                  style: kTitleTextStyle.copyWith(
-                    color: kkMyrtleGreenWithOpacity,
-                  ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                textValue,
+                style: kTitleTextStyle.copyWith(
+                  color: kkMyrtleGreenWithOpacity,
                 ),
-                const SizedBox(width: 10),
-                Text(
+              ),
+              const SizedBox(width: 10),
+              Flexible(
+                child: Text(
                   textDescription,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 2,
                   style: kCaptionTextStyle.copyWith(
                     fontWeight: FontWeight.w300,
                     color: kkMyrtleGreenWithOpacity,
                   ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/src/constants/app_colors_constants.dart
+++ b/lib/src/constants/app_colors_constants.dart
@@ -15,6 +15,7 @@
 import 'package:flutter/material.dart';
 
 const Color kAmaranthPrimary = Color(0xFFE14658);
+const Color kPrimaryColorWithOpacityBG = Color(0x1FFFC9CF);
 const Color kMyrtleGreen = Color(0xFF353C61);
 const Color kGreyDisable = Color(0xFF888888);
 const Color kCanyonBronze = Color(0XFF2F323A);
@@ -25,6 +26,8 @@ const Color kDarkDisable = Color(0xFFF8F8F8);
 const Color kkAmaranthPrimaryWithOpacity = Color.fromRGBO(225, 70, 88, 0.73);
 const Color kLightShadowColor = Color.fromRGBO(0, 0, 0, 0.35);
 const Color kGreen = Color(0XFF159700);
+const Color kBoxShadowColor = Color(0x1A000000);
+const Color kkMyrtleGreenWithOpacity = Color.fromRGBO(53, 60, 97, 0.73);
 
 // Dialogs
 const Color kBarrierColor = Color.fromRGBO(0, 0, 0, 0.5);

--- a/lib/src/constants/app_colors_constants.dart
+++ b/lib/src/constants/app_colors_constants.dart
@@ -28,7 +28,6 @@ const Color kkMyrtleGreenWithOpacity = Color.fromRGBO(53, 60, 97, 0.73);
 const Color kLightShadowColor = Color.fromRGBO(0, 0, 0, 0.35);
 const Color kGreen = Color(0XFF159700);
 const Color kBoxShadowColor = Color(0x1A000000);
-const Color kkMyrtleGreenWithOpacity = Color.fromRGBO(53, 60, 97, 0.73);
 
 // Dialogs
 const Color kBarrierColor = Color.fromRGBO(0, 0, 0, 0.5);

--- a/test/src/components/horizontal_info_card_test.dart
+++ b/test/src/components/horizontal_info_card_test.dart
@@ -1,0 +1,64 @@
+import 'package:carmanager_ui/carmanager_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'base/base_component_app.dart';
+
+void main() {
+  testWidgets('HorizontalInfoCard renders with provided textValue and textDescription', (WidgetTester tester) async {
+    const textValue = '1000';
+    const textDescription = 'Description';
+
+    await tester.pumpWidget(
+      baseComponentApp(
+        const HorizontalInfoCard(
+          textValue: textValue,
+          textDescription: textDescription,
+        ),
+      ),
+    );
+
+    expect(find.text(textValue), findsOneWidget);
+    expect(find.text(textDescription), findsOneWidget);
+  });
+
+  testWidgets('HorizontalInfoCard displays text with correct styles', (WidgetTester tester) async {
+    const textValue = '1000';
+    const textDescription = 'Description';
+
+    await tester.pumpWidget(
+      baseComponentApp(
+        const HorizontalInfoCard(
+          textValue: textValue,
+          textDescription: textDescription,
+        ),
+      ),
+    );
+
+    final textValueWidget = tester.widget<Text>(find.text(textValue));
+    final textDescriptionWidget = tester.widget<Text>(find.text(textDescription));
+
+    expect(textValueWidget.style?.color, equals(kkMyrtleGreenWithOpacity));
+    expect(textValueWidget.style?.fontSize, equals(kTitleTextStyle.fontSize));
+
+    expect(textDescriptionWidget.style?.color, equals(kkMyrtleGreenWithOpacity));
+    expect(textDescriptionWidget.style?.fontWeight, equals(FontWeight.w300));
+  });
+
+  testWidgets('HorizontalInfoCard has correct shadow and border radius', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      baseComponentApp(
+        const HorizontalInfoCard(
+          textValue: '1000',
+          textDescription: 'Description',
+        ),
+      ),
+    );
+
+    final container = tester.widget<Container>(find.byType(Container).first);
+    final decoration = container.decoration as BoxDecoration;
+
+    expect(decoration.boxShadow?.first.color, equals(kBoxShadowColor));
+    expect(decoration.borderRadius, equals(const BorderRadius.all(Radius.circular(6))));
+  });
+}

--- a/test/src/components/horizontal_info_card_test.dart
+++ b/test/src/components/horizontal_info_card_test.dart
@@ -1,3 +1,17 @@
+// Copyright 2024 Danchez
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'package:carmanager_ui/carmanager_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
## Jira ticket
[CARMAN-236](https://danchez.atlassian.net/browse/CARMAN-236)

### Description
HorizontalInfoCard widget moved to UI package

### Evidence

https://github.com/user-attachments/assets/aa31316a-49c1-4bc3-9d4c-0a646f03e4cf

### Depends on
Link to pull requests that are needed for this PR. If this PR depends on other PR, please add Don’t merge label.
