### PR TITLE
[CARMAN-283] Fix CMPageTitle Alignment

### DIFF
--- a/example/lib/showcases/page_title_showcase.dart
+++ b/example/lib/showcases/page_title_showcase.dart
@@ -43,6 +43,14 @@ class PageTitleShowcase extends StatelessWidget {
           boldTitle: 'Dart',
           showBottomDivider: false,
         ),
+        createShowcaseTitle('Long text example.'),
+        const CMPageTitle(
+          lightTitle:
+              'This is a very long title that will be truncated if it exceeds the maximum number of lines.',
+          boldTitle:
+              'Flutter Showcase Large Title Example with Long Text and Truncation',
+          showBottomDivider: true,
+        ),
       ],
     );
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -39,7 +39,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1+2"
+    version: "0.0.1+3"
   characters:
     dependency: transitive
     description:

--- a/lib/src/components/cm_page_title.dart
+++ b/lib/src/components/cm_page_title.dart
@@ -59,7 +59,10 @@ class CMPageTitle extends StatelessWidget {
           ),
           Text(
             boldTitle,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
             style: kTitleTextStyle.copyWith(fontWeight: FontWeight.w600),
+            textAlign: TextAlign.center,
           ),
           Visibility(
             visible: showBottomDivider,


### PR DESCRIPTION
## Jira ticket
[CARMAN-283](https://danchez.atlassian.net/browse/CARMAN-283)

### Description
Adjust page title alignment and add long title showcase

### Evidence
![WhatsApp Image 2025-02-03 at 8 01 26 PM](https://github.com/user-attachments/assets/ae99d093-56c3-40a4-a358-16f2cf09285e)

### Checklist

Please ensure that you have completed the following before submitting your pull request:

- [ ] Run `dart format .` to ensure the code is properly formatted.
- [ ] Run `flutter analyze --no-fatal-infos` and verify there are no warnings or issues.
- [ ] Run `flutter test` and confirm that all tests pass successfully.

Failure to complete these steps may result in delays in reviewing your pull request.

### Depends on
Link to pull requests that are needed for this PR. If this PR depends on other PR, please add Don’t merge label.
