### PR TITLE
[CARMAN-287] CMDateButton moved to package

### DIFF
--- a/example/lib/components_showcases.dart
+++ b/example/lib/components_showcases.dart
@@ -16,6 +16,7 @@ import 'package:car_manager_ui/component_model.dart';
 import 'package:car_manager_ui/showcases/brief_card_showcase.dart';
 import 'package:car_manager_ui/showcases/button_showcase.dart';
 import 'package:car_manager_ui/showcases/cm_appbar/cm_appbar_showcase.dart';
+import 'package:car_manager_ui/showcases/date_button_showcase.dart';
 import 'package:car_manager_ui/showcases/dialogs_showcase.dart';
 import 'package:car_manager_ui/showcases/dropdown_showcase.dart';
 import 'package:car_manager_ui/showcases/empty_list_showcase.dart';
@@ -105,5 +106,9 @@ final components = {
   ComponentModel(
     description: 'CMToggleButton',
     path: ToggleButtonShowcase.path,
+  ),
+  ComponentModel(
+    description: 'CMDateButton',
+    path: DateButtonShowcase.path,
   ),
 };

--- a/example/lib/navigation/go_router_provider.dart
+++ b/example/lib/navigation/go_router_provider.dart
@@ -18,6 +18,7 @@ import 'package:car_manager_ui/showcases/button_showcase.dart';
 import 'package:car_manager_ui/showcases/cm_appbar/cm_appbar_back_showcase.dart';
 import 'package:car_manager_ui/showcases/cm_appbar/cm_appbar_no_back_showcase.dart';
 import 'package:car_manager_ui/showcases/cm_appbar/cm_appbar_showcase.dart';
+import 'package:car_manager_ui/showcases/date_button_showcase.dart';
 import 'package:car_manager_ui/showcases/dialogs_showcase.dart';
 import 'package:car_manager_ui/showcases/dropdown_showcase.dart';
 import 'package:car_manager_ui/showcases/empty_list_showcase.dart';
@@ -73,6 +74,16 @@ class GoRouterHelper {
         pageBuilder: (_, state) {
           return _getPage(
             child: const ButtonShowcase(),
+            state: state,
+          );
+        },
+      ),
+      GoRoute(
+        parentNavigatorKey: _appNavigatorKey,
+        path: DateButtonShowcase.path,
+        pageBuilder: (_, state) {
+          return _getPage(
+            child: const DateButtonShowcase(),
             state: state,
           );
         },

--- a/example/lib/showcases/date_button_showcase.dart
+++ b/example/lib/showcases/date_button_showcase.dart
@@ -1,0 +1,53 @@
+// Copyright 2024 Danchez
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:car_manager_ui/showcase_utils.dart';
+import 'package:car_manager_ui/showcases/showcase_app_base.dart';
+import 'package:carmanager_ui/carmanager_ui.dart';
+import 'package:flutter/material.dart';
+
+/// The [DateButtonShowcase] class provides a visual representation of various date buttons.
+class DateButtonShowcase extends StatelessWidget {
+  /// This path is used to navigate to the button showcase using GoRouter.
+  static String path = '/dateButton';
+
+  const DateButtonShowcase({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShowcaseAppBase(
+      title: 'Date button showcase',
+      children: [
+        createShowcaseTitle('CMDateButton', higherSize: true),
+        createShowcaseTitle('Basic configuration'),
+        CMDateButton(
+          txtLabel: 'February 2025',
+          hintText: 'Month',
+          onPressed: () {
+            printValue('Button pressed');
+          },
+        ),
+        createShowcaseTitle('Basic configuration with custom icon'),
+        CMDateButton(
+          txtLabel: 'February 2025',
+          hintText: 'Month',
+          onPressed: () {
+            printValue('Button pressed');
+          },
+          icon: kAddExpenseIconRed,
+        )
+      ],
+    );
+  }
+}

--- a/lib/carmanager_ui.dart
+++ b/lib/carmanager_ui.dart
@@ -15,6 +15,7 @@
 library carmanager_ui;
 
 export 'package:carmanager_ui/src/components/buttons/cm_icon_button.dart';
+export 'package:carmanager_ui/src/components/buttons/cm_date_button.dart';
 export 'package:carmanager_ui/src/components/buttons/primary_button.dart';
 export 'package:carmanager_ui/src/components/buttons/close_icon_button.dart';
 export 'package:carmanager_ui/src/components/cm_appbar.dart';

--- a/lib/src/components/buttons/cm_date_button.dart
+++ b/lib/src/components/buttons/cm_date_button.dart
@@ -1,0 +1,68 @@
+// Copyright 2024 Danchez
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:carmanager_ui/src/constants/cm_icons.dart';
+import 'package:carmanager_ui/src/constants/decoration_constants.dart';
+import 'package:carmanager_ui/src/constants/text_style_constants.dart';
+import 'package:flutter/material.dart';
+
+/// A custom button widget that displays a read-only text field with a suffix icon
+/// and triggers a callback when tapped.
+///
+/// This widget is typically used for date selection, displaying the selected value
+/// as [txtLabel] and showing [hintText] as a label.
+///
+/// Example usage:
+/// ```dart
+/// CMDateButton(
+///   txtLabel: 'February 2025',
+///   hintText: 'Month',
+///   onPressed: () {
+///     // Open a date picker
+///   },
+/// )
+/// ```
+///
+/// By default, it shows [kDropdownIcon] as the suffix icon, but you can
+/// customize it by passing any other widget to the [icon] property.
+class CMDateButton extends StatelessWidget {
+  final String txtLabel;
+  final String hintText;
+  final Widget icon;
+  final VoidCallback onPressed;
+  const CMDateButton({
+    super.key,
+    required this.txtLabel,
+    required this.hintText,
+    required this.onPressed,
+    this.icon = kDropdownIcon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      enableInteractiveSelection: false,
+      readOnly: true,
+      onTap: onPressed,
+      controller: TextEditingController()..text = txtLabel,
+      keyboardType: TextInputType.text,
+      decoration: kTextFieldInputDecoration.copyWith(
+        labelText: hintText,
+        labelStyle: kContentTextStyle,
+        suffixIcon: icon,
+      ),
+      style: kContentTextStyle,
+    );
+  }
+}

--- a/lib/src/constants/cm_icons.dart
+++ b/lib/src/constants/cm_icons.dart
@@ -50,3 +50,5 @@ const kSecurityIcon =
     Icon(Icons.verified_user_outlined, color: kMyrtleGreen, size: 45);
 
 const kStarIcon = Icon(Icons.star, color: kMyrtleGreen, size: 45);
+
+const kDropdownIcon = Icon(Icons.keyboard_arrow_down_outlined, color: kMyrtleGreen);

--- a/test/src/components/buttons/cm_date_button_test.dart
+++ b/test/src/components/buttons/cm_date_button_test.dart
@@ -1,0 +1,80 @@
+// Copyright 2024 Danchez
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:carmanager_ui/src/components/buttons/cm_date_button.dart';
+import 'package:carmanager_ui/src/constants/cm_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../base/base_component_app.dart';
+
+void main() {
+  group('CMDateButton', () {
+    const String txtLabel = '01/01/2025';
+    const String hintText = 'Select Date';
+    bool onPressedCalled = false;
+
+    Widget createWidgetUnderTest({Widget? icon}) {
+      return baseComponentApp(
+        CMDateButton(
+          txtLabel: txtLabel,
+          hintText: hintText,
+          onPressed: () {
+            onPressedCalled = true;
+          },
+          icon: icon ?? kDropdownIcon,
+        ),
+      );
+    }
+
+    setUp(() {
+      onPressedCalled = false;
+    });
+
+    testWidgets('Renders correctly with texts and the default icon', (WidgetTester tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text(txtLabel), findsOneWidget);
+
+      expect(find.text(hintText), findsOneWidget);
+
+      expect(find.byIcon(kDropdownIcon.icon!), findsOneWidget);
+    });
+
+    testWidgets('Displays the correct text in the TextField', (WidgetTester tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      final textField = find.byType(TextField);
+      final textFieldWidget = tester.widget<TextField>(textField);
+      expect(textFieldWidget.controller?.text, txtLabel);
+    });
+
+    testWidgets('Triggers onPressed when tapping on the TextField', (WidgetTester tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      final textField = find.byType(TextField);
+      await tester.tap(textField);
+      await tester.pumpAndSettle();
+
+      expect(onPressedCalled, isTrue);
+    });
+
+    testWidgets('Displays a custom icon when provided', (WidgetTester tester) async {
+      const customIcon = Icon(Icons.calendar_today);
+      await tester.pumpWidget(createWidgetUnderTest(icon: customIcon));
+
+      expect(find.byIcon(Icons.calendar_today), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Jira ticket
[CARMAN-287](https://danchez.atlassian.net/browse/CARMAN-287)

### Description
CMDateButton moved to package

### Evidence

Test coverage:
![image](https://github.com/user-attachments/assets/fd93831e-de3d-4340-aea4-a172b7dae413)

https://github.com/user-attachments/assets/75f8ae37-c7a9-4703-a8a7-52bcd34c54b6

### Checklist

Please ensure that you have completed the following before submitting your pull request:

- [ ] Run `dart format .` to ensure the code is properly formatted.
- [ ] Run `flutter analyze --no-fatal-infos` and verify there are no warnings or issues.
- [ ] Run `flutter test` and confirm that all tests pass successfully.

Failure to complete these steps may result in delays in reviewing your pull request.

### Depends on
Link to pull requests that are needed for this PR. If this PR depends on other PR, please add Don’t merge label.
