### PR TITLE
[CARMAN-282] Solved all info alerts caused by deprecated components due to package updates

### DIFF
--- a/lib/carmanager_ui.dart
+++ b/lib/carmanager_ui.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library carmanager_ui;
-
 export 'package:carmanager_ui/src/components/animations/cm_animation.dart';
 export 'package:carmanager_ui/src/components/buttons/close_icon_button.dart';
 export 'package:carmanager_ui/src/components/buttons/cm_date_button.dart';
@@ -61,4 +59,5 @@ export 'package:carmanager_ui/src/constants/cm_dimens.dart';
 export 'package:carmanager_ui/src/constants/cm_icons.dart';
 export 'package:carmanager_ui/src/constants/text_style_constants.dart';
 export 'package:carmanager_ui/src/utils/cm_scroll_behavior.dart';
+export 'package:carmanager_ui/src/utils/extensions/color_extensions.dart';
 export 'package:carmanager_ui/src/utils/extensions/string_extensions.dart';

--- a/lib/src/components/cm_summary_card.dart
+++ b/lib/src/components/cm_summary_card.dart
@@ -15,6 +15,7 @@
 import 'package:carmanager_ui/src/constants/app_colors_constants.dart';
 import 'package:carmanager_ui/src/constants/cm_dimens.dart';
 import 'package:carmanager_ui/src/constants/text_style_constants.dart';
+import 'package:carmanager_ui/src/utils/extensions/color_extensions.dart';
 import 'package:carmanager_ui/src/utils/extensions/number_extensions.dart';
 import 'package:carmanager_ui/src/utils/extensions/string_extensions.dart';
 import 'package:flutter/material.dart';
@@ -63,7 +64,7 @@ class CMSummaryCard extends StatelessWidget {
             boxShadow: [
               BoxShadow(
                 offset: const Offset(CMDimens.d0, CMDimens.d1),
-                color: kCanyonBronze.withOpacity(0.17),
+                color: kCanyonBronze.withOpacityValue(0.17),
                 blurRadius: CMDimens.d3,
               ),
             ],

--- a/lib/src/constants/button_constants.dart
+++ b/lib/src/constants/button_constants.dart
@@ -15,6 +15,7 @@
 // coverage:ignore-file
 import 'package:carmanager_ui/src/constants/app_colors_constants.dart';
 import 'package:carmanager_ui/src/constants/cm_dimens.dart';
+import 'package:carmanager_ui/src/utils/extensions/color_extensions.dart';
 import 'package:flutter/material.dart';
 
 final kCMButtonStyle = TextButton.styleFrom(
@@ -27,7 +28,7 @@ final kCMButtonStyle = TextButton.styleFrom(
 final kCMOutlinedButtonStyle = OutlinedButton.styleFrom(
   shape: const StadiumBorder(),
   side: const BorderSide(color: kAmaranthPrimary),
-  disabledBackgroundColor: kAmaranthPrimary.withOpacity(0.3),
+  disabledBackgroundColor: kAmaranthPrimary.withOpacityValue(0.3),
   backgroundColor: kWhite,
   foregroundColor: kAmaranthPrimary,
 );

--- a/lib/src/utils/extensions/color_extensions.dart
+++ b/lib/src/utils/extensions/color_extensions.dart
@@ -1,0 +1,27 @@
+// Copyright 2024 Danchez
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:ui';
+
+extension ColorExtension on Color {
+
+  /// Returns a new color with the given [opacity] value (0.0 to 1.0).
+  Color withOpacityValue(double opacity) {
+    if (opacity > 1.0) {
+      throw ArgumentError('Opacity must be between 0.0 and 1.0.');
+    }
+    int alfa = (opacity * 255).round();
+    return withAlpha(alfa);
+  }
+}

--- a/test/src/components/dialogs/error_dialog_test.dart
+++ b/test/src/components/dialogs/error_dialog_test.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'package:carmanager_ui/carmanager_ui.dart';
-import 'package:carmanager_ui/src/components/buttons/close_icon_button.dart';
 import 'package:carmanager_ui/src/components/dialogs/error/error_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';

--- a/test/src/utils/extensions/color_extensions_test.dart
+++ b/test/src/utils/extensions/color_extensions_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2024 Danchez
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:carmanager_ui/src/utils/extensions/color_extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ColorExtension - withOpacityValue', () {
+
+    const Color testColor = Color(0xFFFF0000);
+
+    test('Opacity 0.0 should result in fully transparent testColor', () {
+      final result = testColor.withOpacityValue(0.0);
+
+      expect(result.a, 0);
+    });
+
+    test('Opacity 1.0 should keep the testColor fully opaque', () {
+
+      final result = testColor.withOpacityValue(1.0);
+
+      expect(result.a, 1);
+    });
+
+    test('Opacity 0.5 should set a to 0.5019607843137255', () {
+
+      final result = testColor.withOpacityValue(0.5);
+
+      expect(result.a, 0.5019607843137255);
+    });
+
+    test('Opacity 0.75 should set a to 0.7490196078431373', () {
+
+      final result = testColor.withOpacityValue(0.75);
+
+      expect(result.a, 0.7490196078431373);
+    });
+
+    test('Opacity greater than 1.0 should throw an ArgumentError', () {
+
+      expect(() => testColor.withOpacityValue(1.1), throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
## Jira ticket
[CARMAN-282](https://danchez.atlassian.net/browse/CARMAN-282)

### Description
Solved all info alerts caused by deprecated components due to package updates

### Evidence
- Before

![image](https://github.com/user-attachments/assets/32c231e1-0639-4caa-bff1-9fef4d7edcd7)

- After

![image](https://github.com/user-attachments/assets/af54348f-bfbe-4dd6-bc77-da2675856f90)

![image](https://github.com/user-attachments/assets/d639047e-405c-42ca-b68f-67c1e2e0c6ff)

### Checklist

Please ensure that you have completed the following before submitting your pull request:

- [ ] Run `dart format .` to ensure the code is properly formatted.
- [x] Run `flutter analyze --no-fatal-infos` and verify there are no warnings or issues.
- [x] Run `flutter test` and confirm that all tests pass successfully.

Failure to complete these steps may result in delays in reviewing your pull request.

### Depends on
Link to pull requests that are needed for this PR. If this PR depends on other PR, please add Don’t merge label.
