### PR TITLE
[SUPPORT] Flag added to textField to show/hide counter

### DIFF
--- a/example/lib/showcases/text_field_showcase.dart
+++ b/example/lib/showcases/text_field_showcase.dart
@@ -63,11 +63,37 @@ class TextFieldShowcase extends StatelessWidget {
           canBeEmpty: true,
           textInputType: TextInputType.number,
         ),
+        createShowcaseTitle(
+            'Can be empty, numbers input with maxLength 10 and show counter'),
+        const CMTextField(
+          hintText: 'Custom hint',
+          onTextChange: printValue,
+          canBeEmpty: true,
+          maxLength: 10,
+          textInputType: TextInputType.number,
+        ),
+        createShowcaseTitle(
+            'Can be empty, numbers input with maxLength 10 and don\'t show counter'),
+        const CMTextField(
+          hintText: 'Custom hint',
+          onTextChange: printValue,
+          canBeEmpty: true,
+          maxLength: 10,
+          showCounter: false,
+          textInputType: TextInputType.number,
+        ),
         createShowcaseTitle('CMMultilineTextField', higherSize: true),
-        createShowcaseTitle('Can be empty, maxLength 100'),
+        createShowcaseTitle('Can be empty, maxLength 100 and show counter'),
         const CMMultilineTextField(
           onTextChange: printValue,
           maxLength: 100,
+        ),
+        createShowcaseTitle(
+            'Can be empty, maxLength 100 and don\'t show counter'),
+        const CMMultilineTextField(
+          onTextChange: printValue,
+          maxLength: 100,
+          showCounter: false,
         ),
         createShowcaseTitle('Can\'t be empty, initial value'),
         const CMMultilineTextField(

--- a/lib/src/components/text_field/cm_multiline_text_field.dart
+++ b/lib/src/components/text_field/cm_multiline_text_field.dart
@@ -28,6 +28,7 @@ class CMMultilineTextField extends TextFieldBase {
     super.maxLength,
     super.style,
     super.initialValue,
+    super.showCounter,
   });
 
   @override
@@ -81,6 +82,9 @@ class _MultilineCMTextField extends State<TextFieldBase> {
         hintText: widget.hintText,
         errorText: _hasError ? _errorText : null,
         labelStyle: _hasError ? kErrorTextStyle : kContentTextStyle,
+        counterStyle:
+            widget.showCounter ? null : TextStyle(height: double.minPositive),
+        counterText: widget.showCounter ? null : '',
       ),
       style: _textStyle,
     );

--- a/lib/src/components/text_field/cm_text_field.dart
+++ b/lib/src/components/text_field/cm_text_field.dart
@@ -31,6 +31,7 @@ class CMTextField extends TextFieldBase {
     super.textInputType,
     super.textCapitalization,
     String super.initialValue = '',
+    super.showCounter,
   });
 
   @override
@@ -90,6 +91,9 @@ class _TextCMTextField extends State<CMTextField> {
         labelText: widget.hintText,
         errorText: _hasError ? _errorText : null,
         labelStyle: _hasError ? kErrorTextStyle : kContentTextStyle,
+        counterStyle:
+            widget.showCounter ? null : TextStyle(height: double.minPositive),
+        counterText: widget.showCounter ? null : '',
       ),
       inputFormatters: inputFormatters,
       style: _textStyle,

--- a/lib/src/components/text_field/text_field_base.dart
+++ b/lib/src/components/text_field/text_field_base.dart
@@ -26,6 +26,7 @@ abstract class TextFieldBase extends StatefulWidget {
   final TextInputType? textInputType;
   final TextCapitalization textCapitalization;
   final String? initialValue;
+  final bool showCounter;
 
   const TextFieldBase({
     super.key,
@@ -40,5 +41,6 @@ abstract class TextFieldBase extends StatefulWidget {
     this.textInputType,
     this.textCapitalization = TextCapitalization.none,
     this.initialValue,
+    this.showCounter = true,
   });
 }

--- a/test/src/components/text_field/cm_multiline_text_field_test.dart
+++ b/test/src/components/text_field/cm_multiline_text_field_test.dart
@@ -101,7 +101,30 @@ void main() {
     );
 
     await tester.enterText(find.byType(TextField), 'Very long input');
+    await tester.pump();
     final textField = tester.widget<TextField>(find.byType(TextField));
+    expect(find.text('10/10'), findsOneWidget);
+    expect(textField.controller?.text.length, 10);
+  });
+
+  testWidgets(
+      'CMMultilineTextField respects maxLength and showCounter is false',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      baseComponentApp(
+        CMMultilineTextField(
+          hintText: 'Enter text',
+          onTextChange: (text) {},
+          maxLength: 10,
+          showCounter: false,
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'Very long input');
+    await tester.pump();
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    expect(find.text('10/10'), findsNothing);
     expect(textField.controller?.text.length, 10);
   });
 

--- a/test/src/components/text_field/cm_text_field_test.dart
+++ b/test/src/components/text_field/cm_text_field_test.dart
@@ -74,8 +74,9 @@ void main() {
     expect(find.text(errorText), findsOneWidget);
   });
 
-  testWidgets('CMTextField respects maxLength', (WidgetTester tester) async {
-    const maxLength = 5;
+  testWidgets('CMTextField respects maxLength and shows counter',
+      (WidgetTester tester) async {
+    const maxLength = 4;
     await tester.pumpWidget(
       baseComponentApp(
         CMTextField(
@@ -87,8 +88,31 @@ void main() {
     );
 
     await tester.enterText(find.byType(TextField), 'Long input');
+    await tester.pump();
     final textField = tester.widget<TextField>(find.byType(TextField));
-    expect(textField.controller!.text.length, lessThanOrEqualTo(maxLength));
+    expect(find.text('4/4'), findsOneWidget);
+    expect(textField.controller!.text.length, equals(maxLength));
+  });
+
+  testWidgets('CMTextField respects maxLength and showCounter is false',
+      (WidgetTester tester) async {
+    const maxLength = 4;
+    await tester.pumpWidget(
+      baseComponentApp(
+        CMTextField(
+          hintText: 'Enter text',
+          maxLength: maxLength,
+          onTextChange: (text) {},
+          showCounter: false,
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'Long input');
+    await tester.pump();
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    expect(find.text('4/4'), findsNothing);
+    expect(textField.controller!.text.length, equals(maxLength));
   });
 
   testWidgets('CMTextField uses correct keyboard type',


### PR DESCRIPTION
## Jira ticket
[CARMAN-XXX](https://danchez.atlassian.net/browse/CARMAN-XXX)

### Description
Flag added to textField to show/hide counter. This is needed for the 'last two digits of the license plate' field in the new set up vehicle view.

### Evidence

https://github.com/user-attachments/assets/1d6d0439-e93f-477a-8c46-3f213e8551bc

![image](https://github.com/user-attachments/assets/b924fb0c-0a46-4de8-9f13-71ae83860261)

### Checklist

Please ensure that you have completed the following before submitting your pull request:

- [x] Run `dart format .` to ensure the code is properly formatted.
- [x] Run `flutter analyze --no-fatal-infos` and verify there are no warnings or issues.
- [x] Run `flutter test` and confirm that all tests pass successfully.

Failure to complete these steps may result in delays in reviewing your pull request.

### Depends on
Link to pull requests that are needed for this PR. If this PR depends on other PR, please add Don’t merge label.
