### PR TITLE
[CARMAN-316] ShowEditIcon flag added to CMPageTitle widget

### DIFF
--- a/example/lib/showcases/page_title_showcase.dart
+++ b/example/lib/showcases/page_title_showcase.dart
@@ -51,6 +51,22 @@ class PageTitleShowcase extends StatelessWidget {
               'Flutter Showcase Large Title Example with Long Text and Truncation',
           showBottomDivider: true,
         ),
+        createShowcaseTitle('Example text with edit icon.'),
+        const CMPageTitle(
+          lightTitle: 'Create report',
+          boldTitle: 'Dart',
+          showBottomDivider: true,
+          showEditIcon: true,
+        ),
+        createShowcaseTitle('Long text example with edit icon.'),
+        const CMPageTitle(
+          lightTitle:
+              'This is a very long title that will be truncated if it exceeds the maximum number of lines.',
+          boldTitle:
+              'Flutter Showcase Large Title Example with Long Text and Truncation',
+          showBottomDivider: true,
+          showEditIcon: true,
+        ),
       ],
     );
   }

--- a/lib/src/components/cm_page_title.dart
+++ b/lib/src/components/cm_page_title.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:carmanager_ui/src/constants/cm_dimens.dart';
+import 'package:carmanager_ui/src/constants/cm_icons.dart';
 import 'package:carmanager_ui/src/constants/dividers.dart';
 import 'package:carmanager_ui/src/constants/text_style_constants.dart';
 import 'package:flutter/material.dart';
@@ -20,8 +22,9 @@ import 'package:flutter/material.dart';
 ///
 /// The [CMPageTitle] widget is used to create a page title with a combination of light and bold text.
 /// It allows you to specify two strings: [lightTitle] and [boldTitle], where the first is styled with
-/// a lighter font weight and the second with a bolder font weight. Additionally, you can control the
-/// visibility of a bottom divider using the [showBottomDivider] property.
+/// a lighter font weight and the second with a bolder font weight. Also, you can control the
+/// visibility of a bottom divider using the [showBottomDivider] property. Additionally yo can show
+/// an edit icon on the right of the [boldTitle].
 ///
 /// This widget is useful for displaying section headers or titles in a consistent manner, with the
 /// ability to adjust text styles and layout.
@@ -38,18 +41,21 @@ class CMPageTitle extends StatelessWidget {
   final String lightTitle;
   final String boldTitle;
   final bool showBottomDivider;
+  final bool showEditIcon;
 
   const CMPageTitle({
     super.key,
     required this.lightTitle,
     required this.boldTitle,
     this.showBottomDivider = true,
+    this.showEditIcon = false,
   });
 
   @override
   Widget build(BuildContext context) {
     return Center(
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Text(
             lightTitle,
@@ -57,12 +63,26 @@ class CMPageTitle extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
             style: kSubtitleTextStyle.copyWith(fontWeight: FontWeight.w300),
           ),
-          Text(
-            boldTitle,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            style: kTitleTextStyle.copyWith(fontWeight: FontWeight.w600),
-            textAlign: TextAlign.center,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Flexible(
+                child: Text(
+                  boldTitle,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: kTitleTextStyle.copyWith(fontWeight: FontWeight.w600),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              Visibility(
+                visible: showEditIcon,
+                child: Padding(
+                  padding: const EdgeInsets.only(left: CMDimens.d8),
+                  child: kEditIcon,
+                ),
+              ),
+            ],
           ),
           Visibility(
             visible: showBottomDivider,

--- a/lib/src/constants/cm_icons.dart
+++ b/lib/src/constants/cm_icons.dart
@@ -127,5 +127,11 @@ const kDropdownIcon = Icon(
 const kInfoIcon = Icon(
   Icons.info_outline,
   color: kMyrtleGreen,
-  size: 22,
+  size: CMDimens.d22,
+);
+
+const kEditIcon = Icon(
+  Icons.edit,
+  color: kMyrtleGreen,
+  size: CMDimens.d20,
 );

--- a/test/src/components/page_title/page_title_test.dart
+++ b/test/src/components/page_title/page_title_test.dart
@@ -87,4 +87,35 @@ void main() {
 
     expect(find.byType(Divider), findsNothing);
   });
+
+  testWidgets('Displays edit icon when showEditIcon is true',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      baseComponentApp(
+        const CMPageTitle(
+          lightTitle: 'Hello',
+          boldTitle: 'World',
+          showBottomDivider: false,
+          showEditIcon: true,
+        ),
+      ),
+    );
+
+    expect(find.byType(Icon), findsOneWidget);
+  });
+
+  testWidgets('Does not display edit icon when showEditIcon is false',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      baseComponentApp(
+        const CMPageTitle(
+          lightTitle: 'Hello',
+          boldTitle: 'World',
+          showEditIcon: false,
+        ),
+      ),
+    );
+
+    expect(find.byType(Icon), findsNothing);
+  });
 }


### PR DESCRIPTION
## Jira ticket
[CARMAN-316](https://danchez.atlassian.net/browse/CARMAN-316)

### Description
Adds a boolean flag to the CMPageTitle widget to control the edit icon's visibility.

### Evidence
![image](https://github.com/user-attachments/assets/7ec21cbf-36d1-472d-a5f1-8fe5f2c2d786)

![image](https://github.com/user-attachments/assets/bc8aacb3-e951-45b9-aeba-9ba04c6cc80c)

### Checklist

Please ensure that you have completed the following before submitting your pull request:

- [x] Run `dart format .` to ensure the code is properly formatted.
- [x] Run `flutter analyze --no-fatal-infos` and verify there are no warnings or issues.
- [x] Run `flutter test` and confirm that all tests pass successfully.

Failure to complete these steps may result in delays in reviewing your pull request.

### Depends on
Link to pull requests that are needed for this PR. If this PR depends on other PR, please add Don’t merge label.
