### PR TITLE
[CARMAN-321] Initial selection added to SelectableVehicleType

### DIFF
--- a/example/lib/showcases/selectable_vehicle_type_showcase.dart
+++ b/example/lib/showcases/selectable_vehicle_type_showcase.dart
@@ -49,6 +49,21 @@ class SelectableVehicleTypeShowcase extends StatelessWidget {
           },
         ),
         createShowcaseTitle(
+            'Basic item list with 2 items and initial selection.'),
+        SelectableVehicleType(
+          items: const [
+            SelectableVehicleTypeItem(
+                id: '1', icon: kSelectableCarImage, description: 'Car'),
+            SelectableVehicleTypeItem(
+                id: '2', icon: kSelectableBikeImage, description: 'Bike'),
+          ],
+          onSelected: (selectedVehicle) {
+            showCustomSnackBar(
+                context, onSelectedVehicleSnackBar(selectedVehicle));
+          },
+          initialSelection: '2',
+        ),
+        createShowcaseTitle(
             'Basic item list with 2 items and long descriptions.'),
         SelectableVehicleType(
           items: const [

--- a/lib/src/components/selectable_vehicle_type/selectable_vehicle_type.dart
+++ b/lib/src/components/selectable_vehicle_type/selectable_vehicle_type.dart
@@ -35,6 +35,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 ///   onSelected: (selectedVehicle) {
 ///     printValue('Selected vehicle: $selectedVehicle');
 ///   },
+///   initialSelection: '1',
 /// )
 /// ```
 class SelectableVehicleType extends StatefulWidget {
@@ -44,10 +45,15 @@ class SelectableVehicleType extends StatefulWidget {
   /// Callback triggered when a vehicle is selected, returning the selected vehicle's ID.
   final ValueChanged<String> onSelected;
 
+  /// The ID of the vehicle type that should be initially selected when the widget is created.
+  /// If null, no vehicle type will be initially selected.
+  final String? initialSelection;
+
   const SelectableVehicleType({
     super.key,
     required this.items,
     required this.onSelected,
+    this.initialSelection,
   });
 
   @override
@@ -61,6 +67,12 @@ class _SelectableVehicleTypeState extends State<SelectableVehicleType> {
   static const double _iconSize = CMDimens.d24;
 
   String? selectedId;
+
+  @override
+  void initState() {
+    super.initState();
+    selectedId = widget.initialSelection;
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/test/src/components/selectable_vehicle_type/selectable_vehicle_type_test.dart
+++ b/test/src/components/selectable_vehicle_type/selectable_vehicle_type_test.dart
@@ -158,5 +158,63 @@ void main() {
       expect(carWidget.style?.color, kMyrtleGreen);
       expect(bikeWidget.style?.color, kWhite);
     });
+    testWidgets(
+        'Initially selects the item with the provided initialSelection ID',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        baseComponentApp(
+          SelectableVehicleType(
+            items: items,
+            onSelected: (_) {},
+            initialSelection: '2',
+          ),
+        ),
+      );
+
+      final carText = tester.widget<Text>(find.text('Car'));
+      final bikeText = tester.widget<Text>(find.text('Bike'));
+
+      expect(carText.style?.color, kMyrtleGreen);
+      expect(bikeText.style?.color, kWhite);
+    });
+
+    testWidgets('Does not select any item if initialSelection is null',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        baseComponentApp(
+          SelectableVehicleType(
+            items: items,
+            onSelected: (_) {},
+            initialSelection: null,
+          ),
+        ),
+      );
+
+      final carText = tester.widget<Text>(find.text('Car'));
+      final bikeText = tester.widget<Text>(find.text('Bike'));
+
+      expect(carText.style?.color, kMyrtleGreen);
+      expect(bikeText.style?.color, kMyrtleGreen);
+    });
+
+    testWidgets(
+        'Does not select any item if initialSelection ID does not exist in items',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        baseComponentApp(
+          SelectableVehicleType(
+            items: items,
+            onSelected: (_) {},
+            initialSelection: '3',
+          ),
+        ),
+      );
+
+      final carText = tester.widget<Text>(find.text('Car'));
+      final bikeText = tester.widget<Text>(find.text('Bike'));
+
+      expect(carText.style?.color, kMyrtleGreen);
+      expect(bikeText.style?.color, kMyrtleGreen);
+    });
   });
 }


### PR DESCRIPTION
## Jira ticket
[CARMAN-321](https://danchez.atlassian.net/browse/CARMAN-321)

### Description
The ability to make an initial selection has been added to the SelectableVehicleType widget.

### Evidence

https://github.com/user-attachments/assets/672d17dc-38a1-4d83-b7e2-1658521f53e6

### Checklist

Please ensure that you have completed the following before submitting your pull request:

- [ ] Run `dart format .` to ensure the code is properly formatted.
- [ ] Run `flutter analyze --no-fatal-infos` and verify there are no warnings or issues.
- [ ] Run `flutter test` and confirm that all tests pass successfully.

Failure to complete these steps may result in delays in reviewing your pull request.

### Depends on
Link to pull requests that are needed for this PR. If this PR depends on other PR, please add Don’t merge label.
