### PR TITLE
[CARMAN-339] Title added to confirmation dialog

### DIFF
--- a/example/lib/showcases/dialogs_showcase.dart
+++ b/example/lib/showcases/dialogs_showcase.dart
@@ -96,6 +96,40 @@ class DialogsShowcase extends StatelessWidget {
             );
           },
         ),
+        createShowcaseTitle(
+            'Confirmation dialog with image, title, subtitle and button'),
+        PrimaryButton(
+          txtLabel: 'Confirm dialog',
+          onPressed: () {
+            context.push(
+              ConfirmDialogRoute.path,
+              extra: _getConfirmDialogContent(
+                title: 'This is the title of the dialog',
+                message: 'This is the message of the dialog',
+                buttonText: 'Accept',
+                image: kSuccessImage,
+                boldPositions: [],
+              ),
+            );
+          },
+        ),
+        createShowcaseTitle(
+            'Confirmation dialog with title, subtitle and button'),
+        PrimaryButton(
+          txtLabel: 'Confirm dialog',
+          onPressed: () {
+            context.push(
+              ConfirmDialogRoute.path,
+              extra: _getConfirmDialogContent(
+                showCloseButton: false,
+                title: 'This is the title of the dialog',
+                message: 'This is the message of the dialog',
+                buttonText: 'Accept',
+                boldPositions: [],
+              ),
+            );
+          },
+        ),
         createShowcaseTitle('ErrorDialog', higherSize: true),
         createShowcaseTitle('Basic error dialog with title an subtitle'),
         PrimaryButton(
@@ -240,6 +274,7 @@ class DialogsShowcase extends StatelessWidget {
       );
 
   ConfirmDialogData _getConfirmDialogContent({
+    String? title,
     required String message,
     required String buttonText,
     required List<int> boldPositions,
@@ -249,6 +284,7 @@ class DialogsShowcase extends StatelessWidget {
     String? image,
   }) {
     return ConfirmDialogData(
+      title: title,
       message: message,
       buttonText: buttonText,
       canPop: canPop,

--- a/lib/src/components/dialogs/confirm/confirm_dialog.dart
+++ b/lib/src/components/dialogs/confirm/confirm_dialog.dart
@@ -57,6 +57,7 @@ class ConfirmDialog extends DialogBase<ConfirmDialogData> {
           children: [
             Visibility(
               visible: data.showCloseButton,
+              replacement: const SizedBox(height: CMDimens.d24),
               child: const Padding(
                 padding: EdgeInsets.only(
                   top: CMDimens.d11,
@@ -74,13 +75,29 @@ class ConfirmDialog extends DialogBase<ConfirmDialogData> {
                 children: [
                   Visibility(
                     visible: data.image != null,
-                    child: SizedBox(
-                      height: CMDimens.d42,
-                      width: CMDimens.d42,
-                      child: SvgPicture.asset(asset),
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: CMDimens.d10),
+                      child: SizedBox(
+                        height: CMDimens.d42,
+                        width: CMDimens.d42,
+                        child: SvgPicture.asset(asset),
+                      ),
                     ),
                   ),
-                  const SizedBox(height: CMDimens.d20),
+                  Visibility(
+                    visible: data.title != null,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: CMDimens.d15,
+                      ),
+                      child: Text(
+                        data.title ?? '',
+                        style: kMediumTitleTextStyle.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                  ),
                   Padding(
                     padding: const EdgeInsets.symmetric(
                       horizontal: CMDimens.d35,

--- a/lib/src/components/dialogs/confirm/confirm_dialog_data.dart
+++ b/lib/src/components/dialogs/confirm/confirm_dialog_data.dart
@@ -16,6 +16,7 @@ import 'package:carmanager_ui/src/constants/string_constants.dart';
 import 'package:flutter/material.dart' show VoidCallback;
 
 class ConfirmDialogData {
+  final String? title;
   final String message;
   final String buttonText;
   final String? image;
@@ -27,6 +28,7 @@ class ConfirmDialogData {
   final bool popWhenOnPressed;
 
   const ConfirmDialogData({
+    this.title,
     required this.message,
     required this.buttonText,
     this.image,

--- a/test/src/components/dialogs/confirm_dialog_test.dart
+++ b/test/src/components/dialogs/confirm_dialog_test.dart
@@ -127,4 +127,39 @@ void main() {
       verify(() => mockNavigator.pop()).called(1);
     },
   );
+
+  testWidgets('Title is displayed when provided', (WidgetTester tester) async {
+    const testTitle = 'Test Title';
+    const dialogData = ConfirmDialogData(
+      title: testTitle,
+      message: 'Message',
+      buttonText: 'Button',
+    );
+    await tester.pumpWidget(
+      baseComponentApp(const ConfirmDialog(data: dialogData)),
+    );
+
+    expect(find.text(testTitle), findsOneWidget);
+  });
+
+  testWidgets('Title is not displayed when not provided',
+      (WidgetTester tester) async {
+    const dialogData = ConfirmDialogData(
+      message: 'Message',
+      buttonText: 'Button',
+      title: null,
+    );
+    await tester.pumpWidget(
+      baseComponentApp(const ConfirmDialog(data: dialogData)),
+    );
+
+    final titleVisibilityFinder = find.byWidgetPredicate(
+      (widget) =>
+          widget is Visibility &&
+          widget.child is Padding &&
+          (widget.child as Padding).child is Text &&
+          !widget.visible,
+    );
+    expect(titleVisibilityFinder, findsWidgets);
+  });
 }


### PR DESCRIPTION
## Jira ticket
[CARMAN-339](https://danchez.atlassian.net/browse/CARMAN-339)

### Description
* Added an optional "title" to the confirmation dialog component. The ConfirmDialogData model, the ConfirmDialog widget, and related code were updated to support and display a dialog title if provided.
* Updated the dialog showcase to include new examples demonstrating the confirmation dialog with a title, subtitle, image, and button.
* Improved the ConfirmDialog implementation so that the title is shown only when provided, with proper layout adjustments.
* Added widget tests to verify that the title displays correctly when present, and is hidden when not set.

### Evidence

[Screen_recording_20250703_112519.webm](https://github.com/user-attachments/assets/4fa6e21b-01e2-4956-8ab2-fb82ea66c88d)


### Checklist

Please ensure that you have completed the following before submitting your pull request:

- [x] Run `dart format .` to ensure the code is properly formatted.
- [x] Run `flutter analyze --no-fatal-infos` and verify there are no warnings or issues.
- [x] Run `flutter test` and confirm that all tests pass successfully.

Failure to complete these steps may result in delays in reviewing your pull request.

### Depends on
Link to pull requests that are needed for this PR. If this PR depends on other PR, please add Don’t merge label.
