### PR TITLE
[CARMAN-308] Add toggle switch callback to VehicleInfoCard

### DIFF
--- a/example/lib/showcases/vehicle_info_card_showcase.dart
+++ b/example/lib/showcases/vehicle_info_card_showcase.dart
@@ -33,6 +33,9 @@ class VehicleInfoCardShowcase extends StatelessWidget {
     const onEditSnackBar = SnackBar(
       content: Text('onEdit pressed'),
     );
+    const onToggleSnackBar = SnackBar(
+      content: Text('toggle pressed'),
+    );
 
     return ShowcaseAppBase(
       title: 'Vehicle info card showcase',
@@ -80,6 +83,21 @@ class VehicleInfoCardShowcase extends StatelessWidget {
           vehicleType: 'Classic Muscle Car',
           onDeletePressed: () => showCustomSnackBar(context, onDeleteSnackBar),
           onEditPressed: () => showCustomSnackBar(context, onEditSnackBar),
+          onToggleSwitch: () => showCustomSnackBar(context, onToggleSnackBar),
+          isToggleActive: false,
+        ),
+        createShowcaseTitle(
+            'Selectable Card - Initially enabled, allowing users to enable details on demand.'),
+        VehicleInfoCard(
+          type: VehicleInfoCardType.toggleable,
+          name: 'Ford Mustang',
+          plate: 'Plate:|MUSCLE99',
+          kms: '80.000|KM',
+          vehicleType: 'Classic Muscle Car',
+          onDeletePressed: () => showCustomSnackBar(context, onDeleteSnackBar),
+          onEditPressed: () => showCustomSnackBar(context, onEditSnackBar),
+          onToggleSwitch: () => showCustomSnackBar(context, onToggleSnackBar),
+          isToggleActive: true,
         ),
       ],
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -39,7 +39,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.1"
+    version: "1.2.2"
   characters:
     dependency: transitive
     description:

--- a/lib/src/components/vehicle_info_card/vehicle_info_card.dart
+++ b/lib/src/components/vehicle_info_card/vehicle_info_card.dart
@@ -30,25 +30,48 @@ import 'package:flutter/material.dart';
 /// - [VehicleInfoCardType.fixed]: Hides the switch and always displays
 ///   the full vehicle details, making the card always active.
 ///
-/// Example usage:
+/// Parameters:
+/// - [name]: The name of the vehicle to be displayed in uppercase.
+/// - [plate]: The license plate information of the vehicle, typically formatted as "Plate:|ABC123".
+/// - [kms]: The mileage of the vehicle, typically formatted as "10.000|KM".
+/// - [vehicleType]: The type or category of the vehicle (e.g., "Electric Vehicle").
+/// - [type]: The display mode of the card, defaults to [VehicleInfoCardType.toggleable].
+/// - [onDeletePressed]: Callback function triggered when the delete button is pressed.
+/// - [onEditPressed]: Callback function triggered when the edit button is pressed.
+/// - [onToggleSwitch]: Callback function triggered when the toggle switch changes state.
+/// - [isToggleActive]: Initial state of the toggle switch, defaults to true. Only applicable when [type] is [VehicleInfoCardType.toggleable].
+///
+/// Example usage with toggleable type:
 /// ```dart
 /// VehicleInfoCard(
 ///   type: VehicleInfoCardType.toggleable,
-///   vehicleInfo: myVehicleInfo,
+///   name: 'Tesla Model S',
+///   plate: 'Plate:|ABC123',
+///   kms: '10.000|KM',
+///   vehicleType: 'Electric Vehicle',
 ///   onDeletePressed: () {
 ///     print('Delete action triggered');
 ///   },
 ///   onEditPressed: () {
 ///     print('Edit action triggered');
 ///   },
+///   onToggleSwitch: () {
+///     print('Toggle switch changed');
+///   },
+///   isToggleActive: true,
 /// )
 /// ```
 ///
-/// When `VehicleInfoCardType.fixed` is used:
+/// Example usage with fixed type:
 /// ```dart
 /// VehicleInfoCard(
 ///   type: VehicleInfoCardType.fixed,
-///   vehicleInfo: myVehicleInfo,
+///   name: 'Ford Mustang',
+///   plate: 'Plate:|MUSCLE99',
+///   kms: '80.000|KM',
+///   vehicleType: 'Classic Muscle Car',
+///   onDeletePressed: () => handleDelete(),
+///   onEditPressed: () => handleEdit(),
 /// )
 /// ```
 class VehicleInfoCard extends StatefulWidget {
@@ -59,6 +82,8 @@ class VehicleInfoCard extends StatefulWidget {
   final VehicleInfoCardType type;
   final VoidCallback? onDeletePressed;
   final VoidCallback? onEditPressed;
+  final VoidCallback? onToggleSwitch;
+  final bool isToggleActive;
 
   const VehicleInfoCard({
     super.key,
@@ -69,6 +94,8 @@ class VehicleInfoCard extends StatefulWidget {
     this.type = VehicleInfoCardType.toggleable,
     this.onDeletePressed,
     this.onEditPressed,
+    this.onToggleSwitch,
+    this.isToggleActive = true,
   });
 
   @override
@@ -81,7 +108,8 @@ class _VehicleInfoCardState extends State<VehicleInfoCard> {
   @override
   void initState() {
     super.initState();
-    _isEnabled = ValueNotifier(widget.type == VehicleInfoCardType.fixed);
+    _isEnabled = ValueNotifier(
+        widget.type == VehicleInfoCardType.fixed || widget.isToggleActive);
   }
 
   @override
@@ -145,7 +173,10 @@ class _VehicleInfoCardState extends State<VehicleInfoCard> {
         if (widget.type == VehicleInfoCardType.toggleable) ...[
           CMSwitch(
             initialValue: _isEnabled.value,
-            onChanged: _toggleSwitch,
+            onChanged: (value) {
+              _toggleSwitch(value);
+              widget.onToggleSwitch?.call();
+            },
           ),
           SizedBox(width: CMDimens.d12),
         ],

--- a/test/src/components/vehicle_info_card/vehicle_info_card_test.dart
+++ b/test/src/components/vehicle_info_card/vehicle_info_card_test.dart
@@ -187,4 +187,31 @@ void main() {
     final kmsSpans = (kmsRichText.text as TextSpan).children!;
     expect((kmsSpans[0] as TextSpan).style!.fontWeight, FontWeight.w600);
   });
+
+  testWidgets('Should call onToggleSwitch callback when switch is toggled',
+      (WidgetTester tester) async {
+    bool toggleSwitchCalled = false;
+
+    await tester.pumpWidget(
+      baseComponentApp(
+        VehicleInfoCard(
+          type: VehicleInfoCardType.toggleable,
+          name: 'Audi A4',
+          plate: 'Plate:|AUD789',
+          kms: '35.000|KM',
+          vehicleType: 'Luxury Sedan',
+          onToggleSwitch: () {
+            toggleSwitchCalled = true;
+          },
+        ),
+      ),
+    );
+
+    // Toggle the switch
+    await tester.tap(find.byType(CMSwitch));
+    await tester.pump();
+
+    // Verify callback was called
+    expect(toggleSwitchCalled, isTrue);
+  });
 }


### PR DESCRIPTION
Introduces the onToggleSwitch callback and isToggleActive property to VehicleInfoCard, allowing external handling of toggle events and initial state. Updates showcase and tests to demonstrate and verify the new functionality.

## Jira ticket
[CARMAN-308(https://danchez.atlassian.net/browse/CARMAN-308)

### Description
Introduces the onToggleSwitch callback and isToggleActive property to VehicleInfoCard, allowing external handling of toggle events and initial state. Updates showcase and tests to demonstrate and verify the new functionality.

### Evidence

https://github.com/user-attachments/assets/df3cac52-b6a6-4405-a360-7dfbefd97188


### Checklist

Please ensure that you have completed the following before submitting your pull request:

- [ ] Run `dart format .` to ensure the code is properly formatted.
- [ ] Run `flutter analyze --no-fatal-infos` and verify there are no warnings or issues.
- [ ] Run `flutter test` and confirm that all tests pass successfully.

Failure to complete these steps may result in delays in reviewing your pull request.

### Depends on
Link to pull requests that are needed for this PR. If this PR depends on other PR, please add Don’t merge label.
