### PR TITLE
[CARMAN-346] Add message overflow option to confirm dialog

### DIFF
--- a/example/lib/showcases/dialogs_showcase.dart
+++ b/example/lib/showcases/dialogs_showcase.dart
@@ -130,6 +130,25 @@ class DialogsShowcase extends StatelessWidget {
             );
           },
         ),
+        createShowcaseTitle(
+            'Confirmation dialog with image, with subtitle and button'),
+        PrimaryButton(
+          txtLabel: 'Confirm dialog',
+          onPressed: () {
+            context.push(
+              ConfirmDialogRoute.path,
+              extra: _getConfirmDialogContent(
+                showCloseButton: false,
+                message:
+                    'Something went wrong. Please|check|your connection and try again.',
+                buttonText: 'Retry',
+                image: kSuccessImage,
+                boldPositions: [1],
+                overflow: TextOverflow.clip,
+              ),
+            );
+          },
+        ),
         createShowcaseTitle('ErrorDialog', higherSize: true),
         createShowcaseTitle('Basic error dialog with title an subtitle'),
         PrimaryButton(
@@ -282,6 +301,7 @@ class DialogsShowcase extends StatelessWidget {
     bool showCloseButton = true,
     bool popWhenOnPressed = true,
     String? image,
+    TextOverflow overflow = TextOverflow.ellipsis,
   }) {
     return ConfirmDialogData(
       title: title,
@@ -293,6 +313,7 @@ class DialogsShowcase extends StatelessWidget {
       boldPositions: boldPositions,
       onPressed: () {},
       image: image,
+      messageOverflow: overflow,
     );
   }
 }

--- a/lib/src/components/cm_rich_text.dart
+++ b/lib/src/components/cm_rich_text.dart
@@ -39,6 +39,7 @@ class CMRichText {
   final FontWeight boldFontWeight;
   final FontWeight contentFontWeight;
   final int? maxLines;
+  final TextOverflow messageOverflow;
 
   const CMRichText({
     required this.text,
@@ -49,6 +50,7 @@ class CMRichText {
     this.boldFontWeight = FontWeight.w600,
     this.contentFontWeight = FontWeight.w300,
     this.maxLines,
+    this.messageOverflow = TextOverflow.ellipsis,
   });
 
   RichText call() {
@@ -72,7 +74,7 @@ class CMRichText {
       textAlign: textAlign,
       text: TextSpan(children: textSpans),
       maxLines: maxLines,
-      overflow: TextOverflow.ellipsis,
+      overflow: messageOverflow,
     );
   }
 

--- a/lib/src/components/dialogs/confirm/confirm_dialog.dart
+++ b/lib/src/components/dialogs/confirm/confirm_dialog.dart
@@ -107,6 +107,7 @@ class ConfirmDialog extends DialogBase<ConfirmDialogData> {
                       textStyle: kSubtitleTextStyle,
                       textDivider: data.textDivider,
                       boldPositions: data.boldPositions,
+                      messageOverflow: data.messageOverflow,
                     )(),
                   ),
                   const SizedBox(height: CMDimens.d30),

--- a/lib/src/components/dialogs/confirm/confirm_dialog_data.dart
+++ b/lib/src/components/dialogs/confirm/confirm_dialog_data.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import 'package:carmanager_ui/src/constants/string_constants.dart';
-import 'package:flutter/material.dart' show VoidCallback;
+import 'package:flutter/material.dart';
 
 class ConfirmDialogData {
   final String? title;
@@ -26,6 +26,7 @@ class ConfirmDialogData {
   final bool canPop;
   final bool showCloseButton;
   final bool popWhenOnPressed;
+  final TextOverflow messageOverflow;
 
   const ConfirmDialogData({
     this.title,
@@ -38,5 +39,6 @@ class ConfirmDialogData {
     this.canPop = true,
     this.showCloseButton = true,
     this.popWhenOnPressed = true,
+    this.messageOverflow = TextOverflow.ellipsis,
   });
 }


### PR DESCRIPTION
## Jira ticket
[CARMAN-346](https://danchez.atlassian.net/browse/CARMAN-346)

### Description
Introduces a configurable TextOverflow property for confirm dialog messages, allowing control over text overflow behavior. Updates ConfirmDialogData, CMRichText, and related usages to support this feature and demonstrates it in the dialogs showcase.

### Evidence

<img width="461" height="1003" alt="image" src="https://github.com/user-attachments/assets/2dc29e60-5579-4f29-bcae-e486459ce258" />


### Checklist

Please ensure that you have completed the following before submitting your pull request:

- [ ] Run `dart format .` to ensure the code is properly formatted.
- [ ] Run `flutter analyze --no-fatal-infos` and verify there are no warnings or issues.
- [ ] Run `flutter test` and confirm that all tests pass successfully.

Failure to complete these steps may result in delays in reviewing your pull request.

### Depends on
Link to pull requests that are needed for this PR. If this PR depends on other PR, please add Don’t merge label.
