### PR TITLE
[CARMAN-352] Align Colors And Margins In Expenses Chart

### DIFF
--- a/lib/src/components/expenses_line_chart/expenses_line_chart.dart
+++ b/lib/src/components/expenses_line_chart/expenses_line_chart.dart
@@ -90,87 +90,97 @@ class _ExpensesLineChartState extends State<ExpensesLineChart> {
     final maxX = widget.values.length < 4 ? 4 : widget.values.length;
 
     return Container(
-      decoration: BoxDecoration(
-        color: kPrimaryColorWithOpacityBG,
-        borderRadius: BorderRadius.all(
-          Radius.circular(CMDimens.d4),
+      decoration: const BoxDecoration(
+          color: kWhite,
+          boxShadow: [
+            BoxShadow(
+              color: kBoxShadowColor,
+              blurRadius: CMDimens.d4,
+              offset: Offset(CMDimens.d0, CMDimens.d5),
+            )
+          ],
+          borderRadius: BorderRadius.all(Radius.circular(CMDimens.d6))),
+      child: Container(
+        decoration: BoxDecoration(
+          color: kPrimaryColorWithOpacityBG,
+          borderRadius: BorderRadius.all(Radius.circular(CMDimens.d6)),
         ),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(CMDimens.d16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              widget.title,
-              style: kExpensesLineTitleTextStyle,
-            ),
-            const SizedBox(height: CMDimens.d16),
-            AspectRatio(
-              aspectRatio: 2.3,
-              child: LineChart(
-                LineChartData(
-                  showingTooltipIndicators:
-                      _LineChartBarDataHelper.getShowingTooltipIndicators(
-                    lineChartBarData,
-                    widget.values,
-                    _touchedIndex,
-                  ),
-                  lineTouchData: LineTouchData(
-                    enabled: true,
-                    handleBuiltInTouches: false,
-                    touchTooltipData: LineTouchTooltipData(
-                      tooltipRoundedRadius: CMDimens.d4,
-                      tooltipMargin: CMDimens.d8,
-                      tooltipPadding: const EdgeInsets.all(CMDimens.d2),
-                      getTooltipColor: (spot) => kExpensesLineChartBg,
-                      getTooltipItems: (List<LineBarSpot> touchedSpots) {
-                        return touchedSpots.map((touchedSpot) {
-                          return LineTooltipItem(
-                            touchedSpot.y.toInt().toString().toMoneyFormat,
-                            kExpensesLineToolTipTextStyle,
-                          );
-                        }).toList();
-                      },
+        child: Padding(
+          padding: const EdgeInsets.all(CMDimens.d16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                widget.title,
+                style: kExpensesLineTitleTextStyle,
+              ),
+              const SizedBox(height: CMDimens.d16),
+              AspectRatio(
+                aspectRatio: 2.3,
+                child: LineChart(
+                  LineChartData(
+                    showingTooltipIndicators:
+                        _LineChartBarDataHelper.getShowingTooltipIndicators(
+                      lineChartBarData,
+                      widget.values,
+                      _touchedIndex,
                     ),
-                    // coverage:ignore-start
-                    touchCallback:
-                        (FlTouchEvent event, LineTouchResponse? touchResponse) {
-                      if (event is FlTapUpEvent &&
-                          touchResponse?.lineBarSpots != null &&
-                          touchResponse?.lineBarSpots?.isNotEmpty == true) {
-                        final spotIndex =
-                            touchResponse?.lineBarSpots!.first.spotIndex;
+                    lineTouchData: LineTouchData(
+                      enabled: true,
+                      handleBuiltInTouches: false,
+                      touchTooltipData: LineTouchTooltipData(
+                        tooltipRoundedRadius: CMDimens.d4,
+                        tooltipMargin: CMDimens.d8,
+                        tooltipPadding: const EdgeInsets.all(CMDimens.d2),
+                        getTooltipColor: (spot) => kExpensesLineChartBg,
+                        getTooltipItems: (List<LineBarSpot> touchedSpots) {
+                          return touchedSpots.map((touchedSpot) {
+                            return LineTooltipItem(
+                              touchedSpot.y.toInt().toString().toMoneyFormat,
+                              kExpensesLineToolTipTextStyle,
+                            );
+                          }).toList();
+                        },
+                      ),
+                      // coverage:ignore-start
+                      touchCallback: (FlTouchEvent event,
+                          LineTouchResponse? touchResponse) {
+                        if (event is FlTapUpEvent &&
+                            touchResponse?.lineBarSpots != null &&
+                            touchResponse?.lineBarSpots?.isNotEmpty == true) {
+                          final spotIndex =
+                              touchResponse?.lineBarSpots!.first.spotIndex;
 
-                        setState(() {
-                          _touchedIndex = spotIndex;
-                        });
-                      }
-                    },
-                    // coverage:ignore-end
-                  ),
-                  lineBarsData: [lineChartBarData],
-                  minX: 0,
-                  maxX: maxX.toDouble(),
-                  minY: widget.values.minY,
-                  maxY: widget.values.maxY,
-                  titlesData: _FlTitlesDataHelper.build(
-                    xPrefix: widget.xPrefix,
-                    xTitles: widget.xTitles,
-                    values: widget.values,
-                  ),
-                  gridData: const FlGridData(show: false),
-                  borderData: FlBorderData(
-                    show: true,
-                    border: const Border(
-                      left: BorderSide(color: kkAmaranthPrimaryWithOpacity),
-                      bottom: BorderSide(color: kkAmaranthPrimaryWithOpacity),
+                          setState(() {
+                            _touchedIndex = spotIndex;
+                          });
+                        }
+                      },
+                      // coverage:ignore-end
+                    ),
+                    lineBarsData: [lineChartBarData],
+                    minX: 0,
+                    maxX: maxX.toDouble(),
+                    minY: widget.values.minY,
+                    maxY: widget.values.maxY,
+                    titlesData: _FlTitlesDataHelper.build(
+                      xPrefix: widget.xPrefix,
+                      xTitles: widget.xTitles,
+                      values: widget.values,
+                    ),
+                    gridData: const FlGridData(show: false),
+                    borderData: FlBorderData(
+                      show: true,
+                      border: const Border(
+                        left: BorderSide(color: kkAmaranthPrimaryWithOpacity),
+                        bottom: BorderSide(color: kkAmaranthPrimaryWithOpacity),
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/components/expenses_line_chart/expenses_line_chart.dart
+++ b/lib/src/components/expenses_line_chart/expenses_line_chart.dart
@@ -91,18 +91,13 @@ class _ExpensesLineChartState extends State<ExpensesLineChart> {
 
     return Container(
       decoration: BoxDecoration(
-        color: kLightAmaranthPrimary,
+        color: kPrimaryColorWithOpacityBG,
         borderRadius: BorderRadius.all(
           Radius.circular(CMDimens.d4),
         ),
       ),
       child: Padding(
-        padding: const EdgeInsets.only(
-          left: CMDimens.d10,
-          right: CMDimens.d16,
-          top: CMDimens.d16,
-          bottom: CMDimens.d12,
-        ),
+        padding: const EdgeInsets.all(CMDimens.d16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/lib/src/components/expenses_line_chart/helpers/line_chart_bar_data_helper.dart
+++ b/lib/src/components/expenses_line_chart/helpers/line_chart_bar_data_helper.dart
@@ -21,11 +21,11 @@ class _LineChartBarDataHelper {
       spots: values.toFlSpots(),
       belowBarData: BarAreaData(
         show: true,
-        color: kLightAmaranthPrimary,
+        color: Colors.transparent,
       ),
       aboveBarData: BarAreaData(
         show: true,
-        color: kLightAmaranthPrimary,
+        color: Colors.transparent,
       ),
       dotData: FlDotData(
         show: true,


### PR DESCRIPTION
## Jira ticket
[CARMAN-352](https://danchez.atlassian.net/browse/CARMAN-352)

### Description
Align colors and margins in expense chart.

### Evidence

<img width="720" height="1600" alt="image" src="https://github.com/user-attachments/assets/8d22d293-1657-499e-b322-3daaa4c2e49d" />

### Checklist

Please ensure that you have completed the following before submitting your pull request:

- [x] Run `dart format .` to ensure the code is properly formatted.
- [x] Run `flutter analyze --no-fatal-infos` and verify there are no warnings or issues.
- [x] Run `flutter test` and confirm that all tests pass successfully.

Failure to complete these steps may result in delays in reviewing your pull request.

### Depends on
Link to pull requests that are needed for this PR. If this PR depends on other PR, please add Don’t merge label.
